### PR TITLE
Fixed bug in getting attribute_value

### DIFF
--- a/src/Model/Resolver/AttributesWithValue.php
+++ b/src/Model/Resolver/AttributesWithValue.php
@@ -82,11 +82,13 @@ class AttributesWithValue implements ResolverInterface
 
         foreach ($product->getAttributes() as $attr) {
             if ($attr->getIsVisibleOnFront()) {
+                $productAttr = $product->getCustomAttribute($attr->getAttributeCode());
+
                 $rawOptions = $attr->getSource()->getAllOptions(true, true);
                 array_shift($rawOptions);
 
                 $attributesToReturn[] = [
-                    'attribute_value' => $attr ? $attr->getValue() : null,
+                    'attribute_value' => $productAttr ? $productAttr->getValue() : null,
                     'attribute_code' => $attr->getAttributeCode(),
                     'attribute_type' => $attr->getFrontendInput(),
                     'attribute_label' => $attr->getFrontendLabel(),


### PR DESCRIPTION
This fixes `attribute_value` always returning `null`. Taken directly from the old resolver code:

https://github.com/scandipwa/catalog-graphql/compare/1.5.2...2.2.0#diff-04294ca97efed236029bad539a2af684L83